### PR TITLE
New version V0.0.3-alpha

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
         run: pnpm i
 
       - name: Type Check
-        run: pnpm type:check
+        run: pnpm type-check
 
       - name: Biome Check
         run: pnpm biome check .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 ## [Unreleased]
 
+## [0.0.3-alpha] - 2024-12-04
+
+### Added
+
+- `Android` 运行打包添加命令行签名参数
+- 添加对 `Android` APP 图标配置的支持
+- 添加对 `Android` 推送图标配置的支持
+- 添加对 `Android` 启动图配置的支持
+- `Android` 的 `Activity` 添加 `android:exported` 属性
+- 添加 `UTS` 插件的打包支持
+- 添加 `Android` 原生插件的打包支持
+
+### Fixed
+
+- 修复测试脚本出错
+- 修复添加 `Android` 平台出错
+- 修复 `--verbose` 无效的问题
+- 修复 `Android` 热线声明配置无效
+
+### Changed
+
+- 一些命令的输出文案优化
+- `create` 命令重构，弃用 `@vue/cli`
+- `log` 公共方法优化
+- `requirement` 命令重构
+- 错误输出优化，用户 `Ctrl-C` 主动取消，不要输出错误信息
+- `transform` 命令重构，添加对 `vue2` 项目的支持
+- 依赖 `inquirer` 更改为 `@inquirer/prompts`
+- `bin` 文件修改
+- `platform` 命令优化
+- `Android` 运行热更新优化
+- `Android` 打包依赖升级 `AGP`，从而支持 `JDK17`
+
 ## [0.0.2-alpha] - 2024-11-12
 
 ### Fixed
@@ -16,6 +49,7 @@
 
 First version.
 
-[unreleased]: https://github.com/wtto00/biome-config/compare/v0.0.2-alpha...HEAD
-[0.0.1-alpha]: https://github.com/wtto00/biome-config/releases/tag/v0.0.2-alpha
-[0.0.1-alpha]: https://github.com/wtto00/biome-config/releases/tag/v0.0.1-alpha
+[unreleased]: https://github.com/wtto00/uniapp-cli/compare/v0.0.3-alpha...HEAD
+[0.0.3-alpha]: https://github.com/wtto00/uniapp-cli/releases/tag/v0.0.3-alpha
+[0.0.2-alpha]: https://github.com/wtto00/uniapp-cli/releases/tag/v0.0.2-alpha
+[0.0.1-alpha]: https://github.com/wtto00/uniapp-cli/releases/tag/v0.0.1-alpha

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniapp-cli-doc",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "description": "Document of CLI for uniapp.",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wtto00/uniapp-cli",
-  "version": "0.0.2-alpha",
+  "version": "0.0.3-alpha",
   "description": "CLI for uniapp.",
   "type": "module",
   "bin": {

--- a/src/android/splashscreen.ts
+++ b/src/android/splashscreen.ts
@@ -1,3 +1,4 @@
+import { readdirSync, rmSync } from 'node:fs'
 import { extname, join } from 'node:path'
 import { App } from '../utils/app.js'
 import { AndroidDir } from '../utils/path.js'
@@ -10,6 +11,15 @@ export function appendSplashScreen(results: Results) {
   const splashscreen = manifest['app-plus']?.distribute?.splashscreen
   if (splashscreen?.androidStyle !== 'default') {
     // 通用启动界面
+    const resourceDir = join(AndroidDir, 'app/src/main/res')
+    for (const size of resourceSizes) {
+      const sizePath = join(resourceDir, `drawable-${size}`)
+      const files = readdirSync(sizePath)
+      const splashImage = files.find((file) => file.startsWith('splash.'))
+      if (splashImage) {
+        rmSync(join(sizePath, splashImage))
+      }
+    }
     return
   }
   // 自定义启动界面

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,1 +1,1 @@
-export const CLI_VERSION = '0.0.2-alpha'
+export const CLI_VERSION = '0.0.3-alpha'

--- a/tests/android.test.ts
+++ b/tests/android.test.ts
@@ -1,10 +1,8 @@
 import assert from 'node:assert'
-import { rm, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs'
 import { after, before, describe, it } from 'node:test'
 import { execaSync } from 'execa'
-import { readJsonFile } from '../src/utils/file.js'
 import Log from '../src/utils/log.js'
-import { AndroidAbiFilters, type ManifestConfig } from '../src/utils/manifest.config.js'
 import { execaUniapp, execaUniappSync } from './helper.js'
 
 describe('android', () => {
@@ -34,52 +32,7 @@ describe('android', () => {
 
   it('add', { timeout: 60000 }, async () => {
     const { stdout } = await execaUniapp('platform add android')
-
-    assert.equal(stdout, Log.errorColor('平台 android 添加失败: 请在文件manifest.json中配置应用名称: name'))
-    const manifest = readJsonFile<ManifestConfig>('src/manifest.json', true)
-
-    manifest.name = 'Test Project Platform'
-    writeFileSync('src/manifest.json', JSON.stringify(manifest, null, 2), 'utf8')
-    const { stdout: stdout1 } = await execaUniapp('platform add android')
-    assert.equal(stdout1, Log.errorColor('平台 android 添加失败: 请在文件manifest.json中配置应用appid: appid'))
-
-    manifest.appid = '__UNI__1FC8DF9'
-    writeFileSync('src/manifest.json', JSON.stringify(manifest, null, 2), 'utf8')
-    const { stdout: stdout2 } = await execaUniapp('platform add android')
-    assert.equal(
-      stdout2,
-      Log.errorColor(
-        '平台 android 添加失败: 请在文件manifest.json中配置应用Appkey: app-plus.distribute.android.dcloud_appkey',
-      ),
-    )
-
-    if (manifest['app-plus']?.distribute?.android)
-      manifest['app-plus'].distribute.android.dcloud_appkey = 'c1b4ac7b9a38a1036528ac460ac70f18'
-    writeFileSync('src/manifest.json', JSON.stringify(manifest, null, 2), 'utf8')
-    const { stdout: stdout3 } = await execaUniapp('platform add android')
-    assert.equal(
-      stdout3,
-      Log.errorColor(
-        '平台 android 添加失败: 请在文件manifest.json中配置应用包名: app-plus.distribute.android.packagename',
-      ),
-    )
-
-    if (manifest['app-plus']?.distribute?.android)
-      manifest['app-plus'].distribute.android.packagename = 'com.example.uniapp'
-    writeFileSync('src/manifest.json', JSON.stringify(manifest, null, 2), 'utf8')
-    const { stdout: stdout4 } = await execaUniapp('platform add android')
-    assert.equal(
-      stdout4,
-      Log.errorColor(
-        '平台 android 添加失败: 请在文件manifest.json中配置应用所支持的CPU类型: app-plus.distribute.android.abiFilters',
-      ),
-    )
-
-    if (manifest['app-plus']?.distribute?.android)
-      manifest['app-plus'].distribute.android.abiFilters = [AndroidAbiFilters.x64, AndroidAbiFilters.ARM64]
-    writeFileSync('src/manifest.json', JSON.stringify(manifest, null, 2), 'utf8')
-    const { stdout: stdout5 } = await execaUniapp('platform add android')
-    assert.equal(stdout5, Log.successColor('平台 android 已成功添加'))
+    assert.equal(stdout, Log.successMessage('平台 android 已成功添加'))
   })
 
   it('remove', { timeout: 60000, todo: true })

--- a/tests/android.test.ts
+++ b/tests/android.test.ts
@@ -32,7 +32,7 @@ describe('android', () => {
 
   it('add', { timeout: 60000 }, async () => {
     const { stdout } = await execaUniapp('platform add android')
-    assert.equal(stdout, Log.successMessage('平台 android 已成功添加'))
+    assert.equal(stdout, Log.successMessage('android 平台已成功添加'))
   })
 
   it('remove', { timeout: 60000, todo: true })


### PR DESCRIPTION
close #79 #78 

### Added

- `Android` 运行打包添加命令行签名参数
- 添加对 `Android` APP 图标配置的支持
- 添加对 `Android` 推送图标配置的支持
- 添加对 `Android` 启动图配置的支持
- `Android` 的 `Activity` 添加 `android:exported` 属性
- 添加 `UTS` 插件的打包支持
- 添加 `Android` 原生插件的打包支持

### Fixed

- 修复测试脚本出错
- 修复添加 `Android` 平台出错
- 修复 `--verbose` 无效的问题
- 修复 `Android` 热线声明配置无效

### Changed

- 一些命令的输出文案优化
- `create` 命令重构，弃用 `@vue/cli`
- `log` 公共方法优化
- `requirement` 命令重构
- 错误输出优化，用户 `Ctrl-C` 主动取消，不要输出错误信息
- `transform` 命令重构，添加对 `vue2` 项目的支持
- 依赖 `inquirer` 更改为 `@inquirer/prompts`
- `bin` 文件修改
- `platform` 命令优化
- `Android` 运行热更新优化
- `Android` 打包依赖升级 `AGP`，从而支持 `JDK17`